### PR TITLE
Add fallback texture source and datagen provider

### DIFF
--- a/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/DynamicAssetGeneratorClient.java
+++ b/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/DynamicAssetGeneratorClient.java
@@ -12,6 +12,7 @@ import net.minecraft.resources.ResourceLocation;
 public class DynamicAssetGeneratorClient {
     public static void init() {
         JsonReaderAPI.registerTexSourceReadingType(new ResourceLocation(DynamicAssetGenerator.MOD_ID,"texture"),new TextureReader());
+        JsonReaderAPI.registerTexSourceReadingType(new ResourceLocation(DynamicAssetGenerator.MOD_ID,"fallback_texture"),new FallbackTextureReader());
         JsonReaderAPI.registerTexSourceReadingType(new ResourceLocation(DynamicAssetGenerator.MOD_ID,"combined_paletted_image"),new CombinedPaletteImage());
         JsonReaderAPI.registerTexSourceReadingType(new ResourceLocation(DynamicAssetGenerator.MOD_ID,"overlay"),new Overlay());
         JsonReaderAPI.registerTexSourceReadingType(new ResourceLocation(DynamicAssetGenerator.MOD_ID,"mask"),new Mask());

--- a/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/client/json/FallbackTextureReader.java
+++ b/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/client/json/FallbackTextureReader.java
@@ -1,0 +1,49 @@
+package io.github.lukebemish.dynamic_asset_generator.client.json;
+
+import com.google.gson.*;
+import com.google.gson.annotations.Expose;
+import com.mojang.blaze3d.platform.NativeImage;
+import io.github.lukebemish.dynamic_asset_generator.DynamicAssetGenerator;
+import io.github.lukebemish.dynamic_asset_generator.client.api.json.ITexSource;
+import io.github.lukebemish.dynamic_asset_generator.client.util.ImageUtils;
+import net.minecraft.resources.ResourceLocation;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class FallbackTextureReader implements ITexSource {
+    public static Gson gson = new GsonBuilder()
+            .excludeFieldsWithoutExposeAnnotation()
+            .create();
+
+    @Override
+    public Supplier<NativeImage> getSupplier(String inputStr) throws JsonSyntaxException{
+        LocationSource locationSource = gson.fromJson(inputStr, LocationSource.class);
+        ResourceLocation rl = ResourceLocation.of(locationSource.path,':');
+        ResourceLocation out_rl = new ResourceLocation(rl.getNamespace(), "textures/"+rl.getPath()+".png");
+        ResourceLocation fallback_rl = ResourceLocation.of(locationSource.fallback,':');
+        ResourceLocation fallback_out_rl = new ResourceLocation(fallback_rl.getNamespace(), "textures/"+fallback_rl.getPath()+".png");
+        return () -> {
+            try {
+                return ImageUtils.getImage(out_rl);
+            } catch (IOException e) {
+                DynamicAssetGenerator.LOGGER.debug("Issue loading main texture: {}, trying fallback", rl);
+                try {
+                    return ImageUtils.getImage(fallback_out_rl);
+                } catch (IOException e2) {
+                    DynamicAssetGenerator.LOGGER.error("Issue loading main and fallback textures: {}, {}", rl, fallback_rl);
+                }
+            }
+            return null;
+        };
+    }
+
+    public static class LocationSource {
+        @Expose
+        String source_type;
+        @Expose
+        public String path;
+        @Expose
+        public String fallback;
+    }
+}

--- a/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/ImageSource.java
+++ b/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/ImageSource.java
@@ -1,0 +1,399 @@
+package io.github.lukebemish.dynamic_asset_generator.datagen;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.github.lukebemish.dynamic_asset_generator.DynamicAssetGenerator;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("unused")
+public abstract class ImageSource {
+    private final TextureConfigProvider provider;
+    private final String type;
+
+    protected ImageSource(TextureConfigProvider provider, String type) {
+        this.provider = provider;
+        this.type = type;
+    }
+
+    protected final void checkExists(ResourceLocation texture) {
+        Preconditions.checkArgument(
+                provider.checkTextureExists(texture),
+                "Texture at %s does not exist",
+                texture
+        );
+    }
+
+    @MustBeInvokedByOverriders
+    JsonObject toJson() {
+        JsonObject object = new JsonObject();
+        object.addProperty("source_type", type);
+        return object;
+    }
+
+    public static final class File extends ImageSource {
+        private final ResourceLocation path;
+
+        File(TextureConfigProvider provider, ResourceLocation path) {
+            super(provider, DynamicAssetGenerator.MOD_ID + ":texture");
+            Preconditions.checkNotNull(path, "Path must not be null");
+            checkExists(path);
+            this.path = path;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(path, "No texture path set");
+
+            JsonObject object = super.toJson();
+            object.addProperty("path", path.toString());
+            return object;
+        }
+    }
+
+    public static final class FallbackFile extends ImageSource {
+        private ResourceLocation path;
+        private ResourceLocation fallback;
+
+        FallbackFile(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":fallback_texture"); }
+
+        public FallbackFile path(ResourceLocation path) {
+            Preconditions.checkNotNull(path, "Path must not be null");
+            checkExists(path);
+
+            this.path = path;
+            return this;
+        }
+
+        public FallbackFile fallback(ResourceLocation fallback) {
+            Preconditions.checkNotNull(fallback, "Fallback must not be null");
+            checkExists(fallback);
+
+            this.fallback = fallback;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(path, "No texture set");
+            Preconditions.checkNotNull(fallback, "No fallback set");
+
+            JsonObject object = super.toJson();
+            object.addProperty("path", path.toString());
+            object.addProperty("fallback", fallback.toString());
+            return object;
+        }
+    }
+
+    public static final class Color extends ImageSource {
+        private final List<Integer> colors = new ArrayList<>();
+        
+        Color(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":color"); }
+
+        public Color color(int color) {
+            colors.add(color);
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            JsonArray colorArray = new JsonArray(colors.size());
+            colors.forEach(colorArray::add);
+
+            JsonObject object = super.toJson();
+            object.add("color", colorArray);
+            return object;
+        }
+    }
+
+    public static final class Overlay extends ImageSource {
+        private final List<ImageSource> inputs = new ArrayList<>();
+
+        Overlay(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":overlay"); }
+
+        public Overlay input(ImageSource input) {
+            Preconditions.checkNotNull(input, "Input source most not be null");
+            inputs.add(input);
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            JsonArray inputArray = new JsonArray(inputs.size());
+            inputs.forEach(input -> inputArray.add(input.toJson()));
+
+            JsonObject object = super.toJson();
+            object.add("inputs", inputArray);
+            return object;
+        }
+    }
+
+    public static final class Mask extends ImageSource {
+        private ImageSource mask = null;
+        private ImageSource input = null;
+
+        Mask(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":mask"); }
+
+        public Mask mask(ImageSource mask) {
+            Preconditions.checkNotNull(mask, "Mask source most not be null");
+            this.mask = mask;
+            return this;
+        }
+
+        public Mask input(ImageSource input) {
+            Preconditions.checkNotNull(input, "Input source most not be null");
+            this.input = input;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(mask, "No mask source set");
+            Preconditions.checkNotNull(input, "No input source set");
+
+            JsonObject object = super.toJson();
+            object.add("mask", mask.toJson());
+            object.add("input", input.toJson());
+            return object;
+        }
+    }
+
+    public static final class Crop extends ImageSource {
+        private ImageSource input = null;
+        private int totalWidth = -1;
+        private int startX = 0;
+        private int startY = 0;
+        private int sizeX = -1;
+        private int sizeY = -1;
+
+        Crop(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":crop"); }
+
+        public Crop input(ImageSource input) {
+            Preconditions.checkNotNull(input, "Input source most not be null");
+            this.input = input;
+            return this;
+        }
+
+        public Crop totalWidth(int totalWidth) {
+            Preconditions.checkArgument(totalWidth > 0, "Total width must be > 0");
+            this.totalWidth = totalWidth;
+            return this;
+        }
+
+        public Crop startX(int startX) {
+            this.startX = startX;
+            return this;
+        }
+
+        public Crop startY(int startY) {
+            this.startY = startY;
+            return this;
+        }
+
+        public Crop sizeX(int sizeX) {
+            Preconditions.checkArgument(sizeX > 0, "Size X must be > 0");
+            this.sizeX = sizeX;
+            return this;
+        }
+
+        public Crop sizeY(int sizeY) {
+            Preconditions.checkArgument(sizeY > 0, "Size Y must be > 0");
+            this.sizeY = sizeY;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(input, "No input source set");
+            Preconditions.checkState(totalWidth != -1, "No total width set");
+            Preconditions.checkState(sizeX != -1, "No size X set");
+            Preconditions.checkState(sizeY != -1, "No size Y set");
+
+            JsonObject object = super.toJson();
+            object.add("input", input.toJson());
+            object.addProperty("total_width", totalWidth);
+            object.addProperty("start_x", startX);
+            object.addProperty("start_y", startY);
+            object.addProperty("size_x", sizeX);
+            object.addProperty("size_y", sizeY);
+            return object;
+        }
+    }
+
+    public static final class Transform extends ImageSource {
+        private ImageSource input = null;
+        private int rotate = 0;
+        private boolean flip = false;
+
+        Transform(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":transform"); }
+
+        public Transform input(ImageSource input) {
+            Preconditions.checkNotNull(input, "Input source most not be null");
+            this.input = input;
+            return this;
+        }
+
+        public Transform rotate(int rotate) {
+            this.rotate = rotate;
+            return this;
+        }
+
+        public Transform flip(boolean flip) {
+            this.flip = flip;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(input, "No input source set");
+
+            JsonObject object = super.toJson();
+            object.add("input", input.toJson());
+            object.addProperty("rotate", rotate);
+            object.addProperty("flip", flip);
+            return object;
+        }
+    }
+
+    public static final class CombinedPalettedImage extends ImageSource {
+        private ImageSource overlay = null;
+        private ImageSource background = null;
+        private ImageSource paletted = null;
+        private boolean includeBackground = false;
+        private boolean stretchPaletted = false;
+        private int extendPaletteSize = 0;
+
+        CombinedPalettedImage(TextureConfigProvider provider) {
+            super(provider, DynamicAssetGenerator.MOD_ID + ":combined_paletted_image");
+        }
+
+        public CombinedPalettedImage overlay(ImageSource overlay) {
+            Preconditions.checkNotNull(overlay, "Overlay source most not be null");
+            this.overlay = overlay;
+            return this;
+        }
+
+        public CombinedPalettedImage background(ImageSource background) {
+            Preconditions.checkNotNull(background, "Background source most not be null");
+            this.background = background;
+            return this;
+        }
+
+        public CombinedPalettedImage paletted(ImageSource paletted) {
+            Preconditions.checkNotNull(paletted, "Paletted source most not be null");
+            this.paletted = paletted;
+            return this;
+        }
+
+        public CombinedPalettedImage includeBackground(boolean includeBackground) {
+            this.includeBackground = includeBackground;
+            return this;
+        }
+
+        public CombinedPalettedImage stretchPaletted(boolean stretchPaletted) {
+            this.stretchPaletted = stretchPaletted;
+            return this;
+        }
+
+        public CombinedPalettedImage extendPaletteSize(int extendPaletteSize) {
+            this.extendPaletteSize = extendPaletteSize;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(overlay, "No overlay source set");
+            Preconditions.checkNotNull(background, "No background source set");
+            Preconditions.checkNotNull(paletted, "No paletted source set");
+
+            JsonObject object = super.toJson();
+            object.add("overlay", overlay.toJson());
+            object.add("background", background.toJson());
+            object.add("paletted", paletted.toJson());
+            object.addProperty("include_background", includeBackground);
+            object.addProperty("stretch_paletted", stretchPaletted);
+            object.addProperty("extend_palette_size", extendPaletteSize);
+            return object;
+        }
+    }
+
+    public static final class ForegroundTransfer extends ImageSource {
+        private ImageSource background = null;
+        private ImageSource full = null;
+        private ImageSource newBackground = null;
+        private boolean trimTrailing = false;
+        private boolean forceNeighbors = false;
+        private boolean fillHoles = false;
+        private int extendPaletteSize = 0;
+        private float closeCutoff = 0F;
+
+        ForegroundTransfer(TextureConfigProvider provider) { super(provider, DynamicAssetGenerator.MOD_ID + ":foreground_transfer"); }
+
+        public ForegroundTransfer background(ImageSource background) {
+            Preconditions.checkNotNull(background, "Background source most not be null");
+            this.background = background;
+            return this;
+        }
+
+        public ForegroundTransfer full(ImageSource full) {
+            Preconditions.checkNotNull(full, "Full source most not be null");
+            this.full = full;
+            return this;
+        }
+
+        public ForegroundTransfer newBackground(ImageSource newBackground) {
+            Preconditions.checkNotNull(newBackground, "New Background source most not be null");
+            this.newBackground = newBackground;
+            return this;
+        }
+
+        public ForegroundTransfer trimTrailing(boolean trimTrailing) {
+            this.trimTrailing = trimTrailing;
+            return this;
+        }
+
+        public ForegroundTransfer forceNeighbors(boolean forceNeighbors) {
+            this.forceNeighbors = forceNeighbors;
+            return this;
+        }
+
+        public ForegroundTransfer fillHoles(boolean fillHoles) {
+            this.fillHoles = fillHoles;
+            return this;
+        }
+
+        public ForegroundTransfer extendPaletteSize(int extendPaletteSize) {
+            Preconditions.checkArgument(extendPaletteSize >= 0, "Extend Palette Size must be >= 0");
+            this.extendPaletteSize = extendPaletteSize;
+            return this;
+        }
+
+        public ForegroundTransfer extendPaletteSize(float closeCutoff) {
+            Preconditions.checkArgument(closeCutoff >= 0F && closeCutoff <= 1F, "Close Cutoff must be between 0 and 1");
+            this.closeCutoff = closeCutoff;
+            return this;
+        }
+
+        @Override
+        JsonObject toJson() {
+            Preconditions.checkNotNull(background, "No background source set");
+            Preconditions.checkNotNull(full, "No full source set");
+            Preconditions.checkNotNull(newBackground, "No new background source set");
+
+            JsonObject object = super.toJson();
+            object.add("background", background.toJson());
+            object.add("full", full.toJson());
+            object.add("new_background", newBackground.toJson());
+            object.addProperty("trim_trailing", trimTrailing);
+            object.addProperty("force_neighbors", forceNeighbors);
+            object.addProperty("fill_holes", fillHoles);
+            object.addProperty("extend_palette_size", extendPaletteSize);
+            object.addProperty("close_cutoff", closeCutoff);
+            return object;
+        }
+    }
+}

--- a/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/TextureConfig.java
+++ b/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/TextureConfig.java
@@ -1,0 +1,35 @@
+package io.github.lukebemish.dynamic_asset_generator.datagen;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+
+@SuppressWarnings("unused")
+public final class TextureConfig {
+    private ImageSource input;
+    private ResourceLocation output;
+
+    public TextureConfig() { }
+
+    public TextureConfig input(ImageSource input) {
+        this.input = input;
+        return this;
+    }
+
+    public TextureConfig output(ResourceLocation output) {
+        Preconditions.checkNotNull(output, "Output texture must not be null");
+
+        this.output = output;
+        return this;
+    }
+
+    JsonObject toJson() {
+        Preconditions.checkNotNull(input, "No input set");
+        Preconditions.checkNotNull(output, "No output set");
+
+        JsonObject object = new JsonObject();
+        object.addProperty("output_location", output.toString());
+        object.add("input", input.toJson());
+        return object;
+    }
+}

--- a/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/TextureConfigProvider.java
+++ b/Common/src/main/java/io/github/lukebemish/dynamic_asset_generator/datagen/TextureConfigProvider.java
@@ -1,0 +1,88 @@
+package io.github.lukebemish.dynamic_asset_generator.datagen;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.data.*;
+import net.minecraft.resources.ResourceLocation;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public abstract class TextureConfigProvider implements DataProvider {
+    private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().create();
+
+    private final DataGenerator generator;
+    private final String modid;
+    private final Map<ResourceLocation, TextureConfig> generatedConfigs = new HashMap<>();
+
+    public TextureConfigProvider(DataGenerator generator, String modid) {
+        this.generator = generator;
+        this.modid = modid;
+    }
+
+    public abstract void addConfigs();
+
+    public final TextureConfig config(String path) {
+        return generatedConfigs.computeIfAbsent(
+                new ResourceLocation(modid, path),
+                loc -> new TextureConfig()
+        );
+    }
+
+    public final ImageSource.File fileSource(ResourceLocation texture) {
+        return new ImageSource.File(this, texture);
+    }
+
+    public final ImageSource.FallbackFile fallbackFileSource() {
+        return new ImageSource.FallbackFile(this);
+    }
+
+    public final ImageSource.Color colorSource() { return new ImageSource.Color(this); }
+
+    public final ImageSource.Overlay overlaySource() { return new ImageSource.Overlay(this); }
+
+    public final ImageSource.Mask maskSource() { return new ImageSource.Mask(this); }
+
+    public final ImageSource.Crop cropSource() { return new ImageSource.Crop(this); }
+
+    public final ImageSource.Transform transformSource() { return new ImageSource.Transform(this); }
+
+    public final ImageSource.CombinedPalettedImage combinedPalettedImageSource() {
+        return new ImageSource.CombinedPalettedImage(this);
+    }
+
+    public final ImageSource.ForegroundTransfer foregroundTransferSource() {
+        return new ImageSource.ForegroundTransfer(this);
+    }
+
+    protected boolean checkTextureExists(ResourceLocation texture) { return true; }
+
+    @Override
+    public final void run(HashCache cache) {
+        generatedConfigs.clear();
+        addConfigs();
+        writeConfigs(cache);
+    }
+
+    private void writeConfigs(HashCache cache) {
+        for (ResourceLocation location : generatedConfigs.keySet()) {
+            Path target = generator.getOutputFolder().resolve(String.format(
+                    "assets/%s/dynamic_assets_sources/%s.json",
+                    location.getNamespace(),
+                    location.getPath()
+            ));
+
+            try {
+                DataProvider.save(GSON, cache, generatedConfigs.get(location).toJson(), target);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public String getName() { return "Texture Configs"; }
+}

--- a/Forge/src/main/java/io/github/lukebemish/dynamic_asset_generator/forge/ForgeTextureConfigProvider.java
+++ b/Forge/src/main/java/io/github/lukebemish/dynamic_asset_generator/forge/ForgeTextureConfigProvider.java
@@ -1,0 +1,23 @@
+package io.github.lukebemish.dynamic_asset_generator.forge;
+
+import io.github.lukebemish.dynamic_asset_generator.datagen.TextureConfigProvider;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraftforge.common.data.ExistingFileHelper;
+
+public abstract class ForgeTextureConfigProvider extends TextureConfigProvider
+{
+    static final ExistingFileHelper.ResourceType TEXTURE = new ExistingFileHelper.ResourceType(PackType.CLIENT_RESOURCES, ".png", "textures");
+    private final ExistingFileHelper fileHelper;
+
+    public ForgeTextureConfigProvider(DataGenerator generator, ExistingFileHelper fileHelper, String modid) {
+        super(generator, modid);
+        this.fileHelper = fileHelper;
+    }
+
+    @Override
+    protected boolean checkTextureExists(ResourceLocation texture) {
+        return fileHelper.exists(texture, TEXTURE);
+    }
+}


### PR DESCRIPTION
This PR adds a fallback texture source and a datagen provider to build texture source configs programmatically, as discussed on Discord.
For Forge users, an extended provider is added, which can validate the existence of input textures via Forge's `ExistingFileHelper`.